### PR TITLE
gcredstash Arm64 and Amd64 binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /debian/files
 /pkg/gcredstash*
 .DS_Store
-./build/linux_*
+/build/linux_*/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /debian/files
 /pkg/gcredstash*
 .DS_Store
+./build/linux_*

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ deb\:docker: clean
 docker\:build\:ubuntu-trusty:
 	docker build -f docker/Dockerfile.ubuntu-trusty -t $(UBUNTU_IMAGE) .
 
+buildx:
+	docker buildx build --platform=linux/amd64 -o build -f docker/Dockerfile .
+	docker buildx build --platform=linux/arm64 -o build -f docker/Dockerfile .
+
 rpm:
 	docker run --name $(CENTOS_CONTAINER_NAME) -v $(shell pwd):/tmp/src $(CENTOS_IMAGE) make -C /tmp/src rpm:docker
 	docker rm $(CENTOS_CONTAINER_NAME)

--- a/cli.go
+++ b/cli.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"gcredstash"
-	"gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash/command"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/commands.go
+++ b/commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/command"
 	"github.com/mitchellh/cli"
 )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:buster AS builder
+
+ARG TARGETARCH
+
+ENV GOOS=linux
+ENV GOARCH=${TARGETARCH}
+ENV GOPATH=/go
+
+# build gcredstash
+COPY . /go/src/github.com/Flipboard/gcredstash
+WORKDIR /go/src/github.com/Flipboard/gcredstash
+RUN make go-get
+RUN go mod tidy
+RUN CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo -o gcredstash-linux-${TARGETARCH}
+RUN ls -la
+
+# Copy the build artifact so we can dump it using the --output argument
+FROM scratch AS export
+ARG TARGETARCH
+COPY --from=builder /go/src/github.com/Flipboard/gcredstash/gcredstash-linux-${TARGETARCH} .

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Flipboard/gcredstash
+
+go 1.16

--- a/src/gcredstash/base64_test.go
+++ b/src/gcredstash/base64_test.go
@@ -1,7 +1,7 @@
 package gcredstash
 
 import (
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"testing"
 )
 

--- a/src/gcredstash/command/delete.go
+++ b/src/gcredstash/command/delete.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"os"
 	"strings"
 )

--- a/src/gcredstash/command/detele_test.go
+++ b/src/gcredstash/command/detele_test.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/golang/mock/gomock"

--- a/src/gcredstash/command/get.go
+++ b/src/gcredstash/command/get.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"github.com/ryanuber/go-glob"
 	"os"
 	"strings"

--- a/src/gcredstash/command/get_test.go
+++ b/src/gcredstash/command/get_test.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/src/gcredstash/command/getall.go
+++ b/src/gcredstash/command/getall.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"os"
 	"strings"
 )

--- a/src/gcredstash/command/getall_test.go
+++ b/src/gcredstash/command/getall_test.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/src/gcredstash/command/list.go
+++ b/src/gcredstash/command/list.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"os"
 	"sort"
 	"strings"

--- a/src/gcredstash/command/list_test.go
+++ b/src/gcredstash/command/list_test.go
@@ -2,9 +2,9 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/golang/mock/gomock"

--- a/src/gcredstash/command/meta.go
+++ b/src/gcredstash/command/meta.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"github.com/mitchellh/cli"
 )
 

--- a/src/gcredstash/command/put.go
+++ b/src/gcredstash/command/put.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"os"
 	"strings"
 )

--- a/src/gcredstash/command/put_test.go
+++ b/src/gcredstash/command/put_test.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/src/gcredstash/command/setup_test.go
+++ b/src/gcredstash/command/setup_test.go
@@ -1,8 +1,8 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/golang/mock/gomock"

--- a/src/gcredstash/command/template.go
+++ b/src/gcredstash/command/template.go
@@ -3,13 +3,13 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
 	"github.com/mattn/go-shellwords"
-	"text/template"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
+	"text/template"
 )
 
 type TemplateCommand struct {

--- a/src/gcredstash/command/template_test.go
+++ b/src/gcredstash/command/template_test.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"gcredstash"
-	. "gcredstash/command"
-	"gcredstash/testutils"
+	"github.com/Flipboard/gcredstash/src/gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash/command"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/src/gcredstash/crypt_test.go
+++ b/src/gcredstash/crypt_test.go
@@ -2,7 +2,7 @@ package gcredstash
 
 import (
 	"bytes"
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"testing"
 )
 

--- a/src/gcredstash/driver_setup_test.go
+++ b/src/gcredstash/driver_setup_test.go
@@ -1,7 +1,7 @@
 package gcredstash
 
 import (
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/golang/mock/gomock"

--- a/src/gcredstash/driver_test.go
+++ b/src/gcredstash/driver_test.go
@@ -1,8 +1,8 @@
 package gcredstash
 
 import (
-	. "gcredstash"
-	"gcredstash/testutils"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
+	"github.com/Flipboard/gcredstash/src/gcredstash/testutils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/src/gcredstash/hex_test.go
+++ b/src/gcredstash/hex_test.go
@@ -1,7 +1,7 @@
 package gcredstash
 
 import (
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"testing"
 )
 

--- a/src/gcredstash/kms_test.go
+++ b/src/gcredstash/kms_test.go
@@ -2,7 +2,7 @@ package gcredstash
 
 import (
 	"bytes"
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/golang/mock/gomock"

--- a/src/gcredstash/optparse_test.go
+++ b/src/gcredstash/optparse_test.go
@@ -1,7 +1,7 @@
 package gcredstash
 
 import (
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"reflect"
 	"testing"
 )

--- a/src/gcredstash/utils_test.go
+++ b/src/gcredstash/utils_test.go
@@ -1,7 +1,7 @@
 package gcredstash
 
 import (
-	. "gcredstash"
+	. "github.com/Flipboard/gcredstash/src/gcredstash"
 	"testing"
 )
 


### PR DESCRIPTION
This is just a stopgap until we can migrate away from `gcredstash` since it's been formally archived.

- Migrates gcredstash to be a go module and uses whatever current version of Go is installed with `golang:buster`. (Although, the go.mod added here says go1.16 and that's because I created it locally, it shouldn't matter anyway). 
- Multistage Docker build to generate multiple architectures. I had to break this up into two separate builds for now (one per platform) because a single build with two platforms wasn't copying the second build into the scratch layer. And then it wouldn't up in the local `--output` folder.
- Manually checking these two binaries into Git for now 🤘 